### PR TITLE
add git-pr-release action

### DIFF
--- a/.github/workflows/git-pr-release.yml
+++ b/.github/workflows/git-pr-release.yml
@@ -1,0 +1,25 @@
+name: git-pr-release
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  git-pr-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+      - run: gem install --no-document git-pr-release
+      - run: git-pr-release --squashed
+        env:
+          GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_PR_RELEASE_BRANCH_PRODUCTION: main
+          GIT_PR_RELEASE_BRANCH_STAGING: develop
+          GIT_PR_RELEASE_LABELS: pr-release
+          TZ: Asia/Tokyo


### PR DESCRIPTION
pretty much the same as what is described in https://songmu.jp/riji/entry/2022-08-05-git-pr-release.html the setup-ruby action uses https://github.com/ruby/setup-ruby as actions/setup-ruby was deprecated.